### PR TITLE
use zsh's command_not_found function

### DIFF
--- a/confs/pkgfile.conf
+++ b/confs/pkgfile.conf
@@ -22,7 +22,6 @@
 #
 # Caveats
 # Bash: requires bash >= 4.0
-# Zsh: will override precmd() and preexec()
 CMD_SEARCH_ENABLED=0
 
 # UPDATE_CRON controls whether the cronjob that runs pkgfile --update

--- a/other/pkgfile-hook.zsh
+++ b/other/pkgfile-hook.zsh
@@ -3,20 +3,15 @@
 # This script will look-up command in the database and suggest
 # installation of packages available from the repository
 #
-function preexec() {
-  command="${1%% *}"
-}
- 
-function precmd() {
-  (($?)) && [ -n "$command" ] && [ -x /usr/bin/pkgfile ] && {
-    which -- "$command" >& /dev/null 
-    if [ $? -ne 0 ]; then
+function command_not_found_handler() {
+  local command="$1"
+  [ -n "$command" ] && [ -x /usr/bin/pkgfile ] && {
+      echo -e "searching for \"$command\" in repos..."
       local pkgs="$(pkgfile -b -v "$command")"
       if [ ! -z "$pkgs" ]; then
         echo -e "\"$command\" may be found in the following packages:\n\n${pkgs}\n"
       fi
-    fi
-    unset command
   }
+  return 1
 }
 # vim: set filetype=zsh :


### PR DESCRIPTION
Hi, I'm the guy from comment 33 in the pkgtools thread.

I have implemented the way in my first paragraph in this commit. I have confirmed that it still terminates "non-existent && echo fail" correctly as the current hooks do.
