### PR TITLE
pkgfile: Add a default value for filelist_dir

### DIFF
--- a/scripts/pkgfile.py
+++ b/scripts/pkgfile.py
@@ -348,7 +348,7 @@ def main():
     try:
         filelist_dir = dict_options['FILELIST_DIR'].rstrip('/')
     except KeyError:
-        pass
+        filelist_dir = FILELIST_DIR
     # PKGTOOLS_DIR is meaningless here
     # CONFIG_DIR is useless
     # RATELIMIT is not used yet


### PR DESCRIPTION
If the KeyError occured, `filelist_dir` would be empty causing pkgfile to crash. The fix is simple: use `FILELIST_DIR` instead.
