### PR TITLE
Andrei Thorp's gem2arch / pkgtools pull request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ pkgtools.tar.gz
 .*.swp
 *.files.*
 scripts/*.pyc
+scripts/gem2arch/*.pyc
 modules/pkgfile.so
 modules/*.o
 modules/build

--- a/Makefile
+++ b/Makefile
@@ -59,14 +59,22 @@ install:
 	# maintpkg
 	$(INSTALL_PROGRAM) scripts/maintpkg $(DESTDIR)$(bindir)/maintpkg
 
+	# gem2arch
+	$(INSTALL_DATA) doc/gem2arch.1 $(DESTDIR)$(mandir)/man1/gem2arch.1
+	$(INSTALL) -d $(DESTDIR)$(sharedir)/gem2arch
+	$(INSTALL_DATA) scripts/gem2arch/*.py $(DESTDIR)$(sharedir)/gem2arch
+	$(INSTALL_PROGRAM) scripts/gem2arch/gem2arch $(DESTDIR)$(sharedir)/gem2arch
+	ln -s /$(sharedir)/gem2arch/gem2arch $(DESTDIR)$(bindir)/gem2arch
+
 uninstall:
 	rm -Rf $(DESTDIR)$(sharedir)
-	rm $(DESTDIR)$(bindir)/{newpkg,pkgfile,spec2arch,pkgconflict,whoneeds,pkgclean}
+	rm $(DESTDIR)$(bindir)/{newpkg,pkgfile,spec2arch,pkgconflict,whoneeds,pkgclean,gem2arch}
 	rm $(DESTDIR)$(crondir)/pkgfile
 	rm $(DESTDIR)$(profiledir)/pkgfile-hook.*
 	rm -Rf $(DESTDIR)$(confdir)/pkgtools
 	rm $(DESTDIR)$(mandir)/man8/spec2arch.8
 	rm $(DESTDIR)$(mandir)/man5/spec2arch.conf.5
+	rm $(DESTDIR)$(mandir)/man1/gem2arch.1
 
 pkgfile.so:
 	(cd modules; python2 ./setup.py build)

--- a/doc/gem2arch.1
+++ b/doc/gem2arch.1
@@ -1,0 +1,46 @@
+.\" generated with Ronn/v0.5
+.\" http://github.com/rtomayko/ronn/
+.
+.TH "GEM2ARCH" "1" "April 2010" "" ""
+.
+.SH "NAME"
+\fBgem2arch\fR \-\- make gem specifications into PKGBUILDs
+.
+.SH "SYNOPSIS"
+\fBgem2arch\fR \fIGEM\fR [\fI\-o\fR \fIDIRECTORY\fR]
+.
+.SH "DESCRIPTION"
+Create a PKGBUILD from the Ruby gem specification for \fIGEM\fR in directory \fIGEM\fR.
+.
+.TP
+\fB\-o\fR \fIDIRECTORY\fR
+Writes PKGBUILD to \fIDIRECTORY\fR instead of \fIGEM\fR.
+.
+.TP
+\fB\-d\fR
+Does not create the PKGBUILD but rather simply lists the dependencies given
+in the gem specfile. A use of this is to automatically generate the
+dependencies of a package by using a loop in shell script.
+.
+.TP
+\fB\-q\fR
+Removes any warning or information messages that would be printed. However,
+errors will still appear (because they tend to be terminal regardless).
+.
+.SH "FILES"
+If \fB/etc/makepkg.conf\fR exists and \fBPACKAGER\fR is uncommented, \fBgem2arch\fR will
+use \fBPACKAGER\fR as the Maintainer for the PKGBUILD.
+.
+.SH "AUTHORS"
+Written by Andrei Thorp and David Campbell.
+.
+.SH "COPYRIGHT"
+gem2arch is Copyright (C) 2010 Andrei Thorp \fIgaroth at the fabulous gmail dot
+com\fR
+.
+.SH "SEE ALSO"
+.
+.TP
+\fBgit repository\fR
+\fIhttp://git.mercenariesguild.net/?p=gem2arch\-garoth.git;a=summary\fR
+

--- a/scripts/gem2arch/gem2arch
+++ b/scripts/gem2arch/gem2arch
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2010-2011 Andrei Thorp <garoth at that gmail thing>
+#
+# gem2arch is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# gem2arch is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+##
+
+import yaml # I use the pure python PyYAML
+from optparse import OptionParser
+import subprocess
+import os
+import sys
+from gemobjects import *
+from pkgobjects import *
+import util
+
+def get_data(gemname):
+    """
+    Uses Ruby's "gem" utility to get the .yaml.
+
+    Returns: the path of the yaml file.
+    """
+    curdir = os.getcwd()
+    workdir = "/tmp/gem2arch"
+    try:
+        if not os.path.exists(workdir):
+            os.mkdir(workdir)
+    except:
+        util.error("Could not create work dir %s" % workdir)
+        sys.exit(1)
+
+    os.chdir(workdir)
+    util.inform("Downloading YAML file...")
+    yamlfile = workdir + "/" + gemname + ".yaml"
+    process = subprocess.Popen("gem spec -rq " + gemname + " > " + yamlfile,
+                               shell=True, stdout=subprocess.PIPE)
+    exit = process.wait()
+    if exit != 0:
+        sys.exit(1)
+    os.chdir(curdir)
+
+    return yamlfile
+
+def write_file(options, pkgbuild, package):
+    """
+    Writes the PKGBUILD to the appropriate file
+    """
+    success = "failure"
+    if options.outdir:
+        try:
+            if not os.path.exists(options.outdir):
+                os.mkdir(options.outdir)
+            f = open(options.outdir + "/PKGBUILD", "w")
+            f.write(str(pkgbuild))
+            f.close()
+            success = "success"
+        except:
+            util.error("Could not write the PKGBUILD file!")
+            sys.exit(1)
+    else:
+        try:
+            if not os.path.exists(package):
+                os.mkdir(package)
+            f = open(package + "/PKGBUILD", "w")
+            f.write(str(pkgbuild))
+            f.close()
+            success = "success"
+        except:
+            util.error("Could not write the PKGBUILD file!")
+    return success
+
+def print_dependencies(gemspec):
+    """
+    Outputs the dependencies listed in the Gem file.
+    """
+    for dependency in gemspec.dependencies:
+        print(dependency.name)
+
+def parse():
+    """
+    Handles parsing of command line arguments using optparse.
+    """
+    usage = "\n%prog GEM [-o DIRECTORY]"
+    description = "Convert Ruby gem specifications into Arch PKGBUILDs"
+    parser = OptionParser(usage=usage, description=description)
+
+    parser.add_option("-q", action="store_true", dest="quiet", default=False,
+                      help="Removes information and warning messages.")
+    parser.add_option("-o", dest="outdir", metavar="DIRECTORY",
+                      help="Writes PKGBUILD to DIRECTORY instead of GEM.")
+    parser.add_option("-d", action="store_true", dest="depsonly", default=False,
+                      help="Only list the dependencies given in the Gem.")
+
+    options, args = parser.parse_args()
+
+    if len(args) != 1:
+        parser.print_help()
+        sys.exit(1)
+
+    return parser, options, args
+
+def main():
+    parser, options, args = parse()
+    package = args[0]
+
+    if options.quiet:
+        util.allowed_levels = [ "E!" ]
+
+    util.inform("Generating PKGBUILD for %s..." % package)
+    yamlfile = get_data(package)
+    gemspec = yaml.load(open(yamlfile))
+
+    if options.depsonly:
+        print_dependencies(gemspec)
+    else:
+        pkgbuild = PKGBUILD(gemspec)
+        success = write_file(options, pkgbuild, package)
+        util.inform("Finished working on %s with %s!" % (package, success))
+
+if __name__ == "__main__":
+        main()

--- a/scripts/gem2arch/gemobjects.py
+++ b/scripts/gem2arch/gemobjects.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+import yaml # I use the pure python PyYAML
+class Timestamp(yaml.YAMLObject):
+    """Avoid errors from files with old YAML timestamps."""
+    yaml_tag = '!timestamp'
+    def __init__(self, at):
+        self.at = at
+
+    def __repr__(self):
+        return '%s(at=%r)' % (self.__class__.__name__, self.at)
+
+class Version(yaml.YAMLObject):
+    yaml_tag = '!ruby/object:Gem::Version'
+    def __init__(self, version):
+        self.version = version
+
+    def __repr__(self):
+        return '%s(version=%r)' % (self.__class__.__name__, self.version)
+
+class Requirement(yaml.YAMLObject):
+    yaml_tag = '!ruby/object:Gem::Requirement'
+    def __init__(self, requirements, version):
+        self.requirements = requirements
+        self.version = version
+
+    def __repr__(self):
+        return '%s(requirements=%r, version=%r)' % (self.__class__.__name__,
+                                                    self.requirements, self.version)
+
+class Dependency(yaml.YAMLObject):
+    yaml_tag = '!ruby/object:Gem::Dependency'
+    _attributes = ['self', 'name type', 'version_requirement',
+                   'version_requirements']
+    def __init__(self, **kwds):
+        for name in self._attributes:
+            setattr(self, name, kwds[name])
+
+    def __repr__(self):
+            return '%s(%s)' % (self.__class__.__name__,
+                               ', '.join('%s=%r' % (k, getattr(self, k))
+                                         for k in self._attributes))
+
+class GemSpec(yaml.YAMLObject):
+    yaml_tag = '!ruby/object:Gem::Specification'
+    _attributes = ['name', 'version', 'platform', 'authors', 'autorequire',
+                   'bindir', 'cert_chain', 'date', 'default_executable',
+                   'dependencies', 'description', 'email', 'executables',
+                   'extensions', 'extra_rdoc_files', 'files', 'has_rdoc',
+                   'homepage', 'licenses', 'post_install_message',
+                   'rdoc_options', 'require_paths', 'requirements',
+                   'rubyforge_project', 'rubygems_version', 'signing_key',
+                   'specification_version', 'summary', 'test_files']
+    def __init__(self, **kwds):
+        for name in self._attributes:
+            setattr(self, name, kwds[name])
+
+    def __repr__(self):
+            return '%s(%s)' % (self.__class__.__name__,
+                               ', '.join('%s=%r' % (k, getattr(self, k))
+                                         for k in self._attributes))

--- a/scripts/gem2arch/pkgobjects.py
+++ b/scripts/gem2arch/pkgobjects.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+import util
+
+class PKGBUILD:
+    def __init__(self, gem_spec):
+        self.maintainer = self.get_maintainer('/etc/makepkg.conf')
+        self.pkgname = "ruby-%s" % (gem_spec.name)
+        self.pkgver = gem_spec.version.version
+        self.pkgrel = "1"
+        self.pkgdesc = self.get_summary(gem_spec.summary)
+        self.arch = "('any')"
+        self.url = '"%s"' % (gem_spec.homepage)
+        self.license = self.get_licenses(getattr(gem_spec, 'licenses', False))
+        self.groups = "()"
+        self.depends = self.get_deps(gem_spec.dependencies)
+        self.makedepends = "('rubygems')"
+        self.optdepends = "()"
+        self.provides = "()"
+        self.conflicts = "()"
+        self.replaces = "()"
+        self.backup = "()"
+        self.options = "()"
+        self.install = ""
+        self.source = '("http://gems.rubyforge.org/gems/%s-${pkgver}.gem")' %\
+                (gem_spec.name)
+        self.noextract = '("%s-${pkgver}.gem")' % (gem_spec.name)
+        self.md5sums = "()" # makepkg already generates md5sums.
+        self.build = """
+  cd $srcdir
+  local _gemdir="$(ruby -rubygems -e'puts Gem.default_dir')"
+  gem install --ignore-dependencies -i "$pkgdir$_gemdir" %s-$pkgver.gem \\
+  -n \"$pkgdir/usr/bin\"
+""" % (gem_spec.name)
+
+    def get_maintainer(self, makepkg_conf):
+        default = 'Your Name <YourEmail "AT" example "DOT" com>'
+        try:
+            for line in open(makepkg_conf):
+                if line.startswith('PACKAGER='):
+                    return line.strip('PACKAGER=\n ')[1:-1]
+            return default
+        except:
+            return default
+
+    def get_licenses(self, licenses):
+        if not licenses or len(licenses) == 0:
+            util.warn("License not found! Figure it out and add it.")
+            return "()"
+        else:
+            return "(%s)" % " ".join('%r' % license for license in licenses)
+
+    def get_summary(self, summary):
+        if len(summary) > 80:
+            util.warn("Summary too long, cut it back to 80 characters.")
+        return "\"" + summary + "\""
+
+# TODO Should look into how to format "version must be greater than x
+#      and less than y". For now, assume that we just get a single
+#      version range restriction
+    def get_version_req(self, dependency):
+        retval = ""
+        for requirement in dependency.version_requirements.requirements:
+            # Requirement could be more than one
+            retval += str(requirement[0])
+            retval += str(requirement[1].version)
+
+        # FIXME what should I really be doing here? "~>1" means "NOT =1".
+        if "~" in retval:
+                retval = ""
+        if retval == ">=0":
+                retval = ""
+        return retval
+
+    def get_deps(self, dependencies, prefix="ruby-"):
+        if not dependencies or len(dependencies) == 0:
+            return "()"
+
+        retval = "('ruby' "
+        for dependency in dependencies:
+            retval += "'" + prefix + dependency.name
+            versionreq = self.get_version_req(dependency)
+            if versionreq != "":
+                retval += versionreq
+            retval += "'"
+            if dependencies.index(dependency) != len(dependencies) - 1:
+                retval += " "
+
+        retval += ")"
+        return retval
+
+    _pkg = ['pkgname', 'pkgver', 'pkgrel', 'pkgdesc', 'arch', 'url', 'license',
+            'groups', 'depends', 'makedepends', 'optdepends', 'provides',
+            'conflicts', 'replaces', 'backup', 'options', 'install', 'source',
+            'noextract', 'md5sums']
+    #The *:set* command is mangled to keep vim from being really annoying.
+    def __repr__(self):
+        return '# Maintainer: %s\n%s\n\nbuild() {%s}\n\n# %s:set ts=2 sw=2 \
+et:' % (self.maintainer, '\n'.join('%s=%s' % (k, getattr(self, k))\
+                                   for k in self._pkg), self.build, 'vim')
+
+    def __str__(self):
+        return self.__repr__()

--- a/scripts/gem2arch/util.py
+++ b/scripts/gem2arch/util.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+import sys
+from functools import reduce
+
+global allowed_levels
+allowed_levels = [ "E!", "W:", "I:" ]
+
+def message(prefix, text):
+    global allowed_levels
+    retval = prefix + " "
+    if prefix in allowed_levels:
+        retval += wrap(text, 75)
+        retval = retval.strip() + "\n"
+        sys.stderr.write(retval)
+
+def error(text):
+    message("E!", text)
+
+def warn(text):
+    message("W:", text)
+
+def inform(text):
+    message("I:", text)
+
+def wrap(text, width):
+    """
+    A word-wrap function that preserves existing line breaks
+    and most spaces in the text. Expects that existing line
+    breaks are posix newlines (\n).
+    """
+    return reduce(lambda line, word, width=width: '%s%s%s' %
+                  (line,
+                   ' \n'[(len(line)-line.rfind('\n')-1
+                         + len(word.split('\n',1)[0]
+                              ) >= width)],
+                   word),
+                  text.split(' ')
+                 )
+
+def indent(string):
+    if string:
+        string = "  " + string
+        string = string.replace("\n", "\n  ")
+        return string


### PR DESCRIPTION
Hello, Daenyth! Hope you're not being crushed by too much work. I've finished a basic import of gem2arch, and would like you to review / further integrate as necessary. It includes changes to the Makefile, gitignore, adds a manpage, etc. I did everything I could think of. However, here are some notes:
- Hope it's fine that I do an ln rather than making a full python module. Lazy.
- I'm not sure why spec2arch is in man 8. That's root-only commands. Put my manpage into man 1 for general executables.
- Read it only briefly, but it looks like your COPYING file is a template and not an actual, filled-out licence file... :)
- I updated gem2arch to python 3 just now... and then realized that the rest of your stuff is python 2. I'm sure you're thinking about updating to python 3 eventually, so I won't change it back yet. It's a simple enough patch to revert if you want my code to be python 2 again.
- I didn't test my integration too closely, so please read over the diff and see what you do/don't like. I didn't want to figure out how you do your PKGBUILD/install testing.
- gem2arch relies on python-yaml. At the moment, the one in the main repo is for python2. In the AUR, there is a package called python3-yaml that I tested and does work with my code. It seems like it's more conventional to call what's in community python2-yaml and import the AUR package as python-yaml. Guess we might need to collaborate with someone on that if you don't force me to make gem2arch python 2 and take a step backwards.

The dependencies for gem2arch are:
python
python3-yaml (AUR)

That is all.
