### PR TITLE
readlink move

### DIFF
--- a/other/pkgfile-hook.sh
+++ b/other/pkgfile-hook.sh
@@ -7,7 +7,7 @@ CMD_SEARCH_ENABLED=0
 #   (trick adapted from /etc/profile)
 if [ $CMD_SEARCH_ENABLED -eq 1 ]; then
     if [ -f /proc/mounts ]; then
-        case $(/bin/readlink /proc/$$/exe) in
+        case $(readlink /proc/$$/exe) in
             /bin/bash) [ -f /usr/share/pkgtools/pkgfile-hook.bash ] && . /usr/share/pkgtools/pkgfile-hook.bash ;;
             /bin/zsh)  [ -f /usr/share/pkgtools/pkgfile-hook.zsh  ] && . /usr/share/pkgtools/pkgfile-hook.zsh  ;;
         esac


### PR DESCRIPTION
coreutils 8.16-2 moved readlink under /usr/bin
