### PR TITLE
Update the gem2arch PKGBUILD

### DIFF
--- a/scripts/gem2arch/pkgobjects.py
+++ b/scripts/gem2arch/pkgobjects.py
@@ -29,7 +29,7 @@ class PKGBUILD:
   cd "${srcdir}"
   local _gemdir="$(ruby -rubygems -e'puts Gem.default_dir')"
   gem install --ignore-dependencies -i "$pkgdir$_gemdir" %s-$pkgver.gem \\
-    -n \"$pkgdir/usr/bin\"
+    -n \"$pkgdir/usr/bin\" --no-user-install
 """ % (gem_spec.name)
 
     def get_maintainer(self, makepkg_conf):


### PR DESCRIPTION
The `--no-user-install` flag is needed because of https://bugs.archlinux.org/task/28681 and not putting the flag creates a partial package containing only a few files while all the rest ends up in the `~/.gem/` folder.
